### PR TITLE
LDP-69: REST server

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/folio-org/mod-ldp/app/config"
+	"github.com/folio-org/mod-ldp/app/handlers"
+	"github.com/gorilla/mux"
+)
+
+type App struct {
+	Router *mux.Router
+	DB     int // *gorm.DB
+}
+
+// App initialize with predefined configuration
+func (a *App) Initialize(config *config.Config) {
+	// dbURI := fmt.Sprintf("%s:%s@/%s?charset=%s&parseTime=True",
+	// 	config.DB.Username,
+	// 	config.DB.Password,
+	// 	config.DB.Name,
+	// 	config.DB.Charset)
+
+	// db, err := gorm.Open(config.DB.Dialect, dbURI)
+	// if err != nil {
+	// 	log.Fatal("Could not connect database")
+	// }
+
+	// a.DB = model.DBMigrate(db)
+
+	a.DB = 0 // temp value until the database connect code above is done
+	a.Router = mux.NewRouter()
+	a.setRouters()
+}
+
+func (a *App) setRouters() {
+	a.Get("/ldp/rt/journal_access_per_time", a.GetJournalAccessPerTime)
+}
+
+// Wrap the router for GET method
+func (a *App) Get(path string, f func(w http.ResponseWriter, r *http.Request)) {
+	a.Router.HandleFunc(path, f).Methods("GET")
+}
+
+// Wrap the router for POST method
+func (a *App) Post(path string, f func(w http.ResponseWriter, r *http.Request)) {
+	a.Router.HandleFunc(path, f).Methods("POST")
+}
+
+// Wrap the router for PUT method
+func (a *App) Put(path string, f func(w http.ResponseWriter, r *http.Request)) {
+	a.Router.HandleFunc(path, f).Methods("PUT")
+}
+
+// Wrap the router for DELETE method
+func (a *App) Delete(path string, f func(w http.ResponseWriter, r *http.Request)) {
+	a.Router.HandleFunc(path, f).Methods("DELETE")
+}
+
+// Handlers to manage data
+func (a *App) GetJournalAccessPerTime(w http.ResponseWriter, r *http.Request) {
+	handlers.GetJournalAccessPerTime(a.DB, w, r)
+}
+
+// Run the app on its router
+func (a *App) Run(host string) {
+
+	srv := &http.Server{
+		Handler:      a.Router,
+		Addr:         host,
+		WriteTimeout: 15 * time.Second,
+		ReadTimeout:  15 * time.Second,
+	}
+	log.Fatal(srv.ListenAndServe())
+}

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -1,0 +1,25 @@
+package config
+
+type Config struct {
+	DB *DBConfig
+}
+
+type DBConfig struct {
+	// Dialect  string
+	Username string
+	// Password string
+	// Name     string
+	// Charset  string
+}
+
+func GetConfig() *Config {
+	return &Config{
+		DB: &DBConfig{
+			// Dialect:  "mysql",
+			Username: "root",
+			// Password: "root",
+			// Name:     "employee",
+			// Charset:  "utf8",
+		},
+	}
+}

--- a/app/handlers/realtime.go
+++ b/app/handlers/realtime.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+)
+
+// int is a placeholder for the database type
+func GetJournalAccessPerTime(val int, w http.ResponseWriter, req *http.Request) {
+	// Example code once the database connection is made:
+	//
+	// employees := []model.Employee{}
+	// db.Find(&employees)
+	// respondJSON(w, http.StatusOK, employees)
+
+	io.WriteString(w, "Hello from JournalAccessPerTime route\n"+strconv.Itoa(val))
+}

--- a/descriptors/ModuleDescriptor.json
+++ b/descriptors/ModuleDescriptor.json
@@ -4,11 +4,17 @@
   "provides" : [ {
     "id" : "hello",
     "version" : "1.1",
-      "handlers" : [ {
-      "methods" : [ "GET", "POST" ],
-      "pathPattern" : "/hello2"
+      "handlers": [ {
+      "methods": [ "GET", "POST" ],
+      "pathPattern" : "/hello2",
+      "permissionsRequired": [ "ldp.hello2" ]
     } ]
   } ],
+  "permissionSets": [{
+    "description": "Get and create Hello objects in the LDP database",
+    "displayName": "LDP -- get and create Hellos",
+    "permissionName": "ldp.hello2"
+  }],
   "launchDescriptor" : {
     "dockerImage" : "mod-ldp"
   }

--- a/descriptors/ModuleDescriptor.json
+++ b/descriptors/ModuleDescriptor.json
@@ -3,17 +3,17 @@
   "name" : "Hello World",
   "provides" : [ {
     "id" : "hello",
-    "version" : "1.1",
+    "version" : "1.0",
       "handlers": [ {
-      "methods": [ "GET", "POST" ],
-      "pathPattern" : "/hello2",
-      "permissionsRequired": [ "ldp.hello2" ]
+      "methods": [ "GET" ],
+      "pathPattern" : "/ldp/rt/journal_access_per_time",
+      "permissionsRequired": [ "ldp.realtime.journal_access_per_time.get" ]
     } ]
   } ],
   "permissionSets": [{
-    "description": "Get and create Hello objects in the LDP database",
-    "displayName": "LDP -- get and create Hellos",
-    "permissionName": "ldp.hello2"
+    "description": "Get journal access per time from the LDP database",
+    "displayName": "LDP -- Get Journal Access Per Time",
+    "permissionName": "ldp.realtime.journal_access_per_time.get"
   }],
   "launchDescriptor" : {
     "dockerImage" : "mod-ldp"

--- a/main.go
+++ b/main.go
@@ -1,20 +1,17 @@
 package main
 
 import (
-	"fmt"
-	"io"
-	"log"
-	"net/http"
+	"github.com/folio-org/mod-ldp/app"
+	"github.com/folio-org/mod-ldp/app/config"
 )
 
+// Using this project as a template
+// http://www.golangprograms.com/advance-programs/golang-restful-api-using-grom-and-gorilla-mux.html
+
 func main() {
-	// Hello world, the web server
+	config := config.GetConfig()
 
-	fmt.Println("Running server!")
-	helloHandler := func(w http.ResponseWriter, req *http.Request) {
-		io.WriteString(w, "Hello, world!\n")
-	}
-
-	http.HandleFunc("/hello2", helloHandler)
-	log.Fatal(http.ListenAndServe(":8001", nil))
+	app := &app.App{}
+	app.Initialize(config)
+	app.Run(":8001")
 }


### PR DESCRIPTION
- added permissionSets to module descriptor so the route now requires auth
- Followed this [template](http://www.golangprograms.com/advance-programs/golang-restful-api-using-grom-and-gorilla-mux.html) in structuring the REST server. I believe the structure is both easily understood and will scale as the codebase increases:
  - config (e.g. database secrets) is separated from app
  - handler definitions are separated from server instantiation
  - each subroute (/ldp/**rt**) can have its own file under the `app/handlers` package
  - database connection is ready to be passed to each handler for retrieving data
  - Using `gorilla/mux` instead of `net/http` means we don't need to parse the URL params ourselves or create switch blocks for the HTTP methods.
