### PR TITLE
MODLDP-37: SQL injection in strings and column names

### DIFF
--- a/src/test/java/org/folio/ldp/QueryServiceImplTest.java
+++ b/src/test/java/org/folio/ldp/QueryServiceImplTest.java
@@ -33,6 +33,15 @@ public class QueryServiceImplTest {
   }
 
   @Test
+  public void generateQueryFilterOps() {
+    var ops = List.of("=", "<>", "<", "<=", ">", ">=", "LIKE", "ILIKE");
+    for (var op: ops) {
+      tq.columnFilters = List.of(new ColumnFilter("col", op, "val"));
+      assertThat(generateQuery(tq), is("SELECT * FROM schema.table WHERE (\"col\" " + op + " 'val') LIMIT 500"));
+    }
+  }
+
+  @Test
   public void generateQueryFilterWithSingleQuotes() {
     tq.columnFilters = List.of(new ColumnFilter("col", ">", "it's cool, it's \"masked\""));
     assertThat(generateQuery(tq), is(

--- a/src/test/java/org/folio/ldp/QueryServiceImplTest.java
+++ b/src/test/java/org/folio/ldp/QueryServiceImplTest.java
@@ -1,0 +1,66 @@
+package org.folio.ldp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+public class QueryServiceImplTest {
+
+  private TableQuery tq;
+
+  @Before
+  public void setUp() {
+    tq = new TableQuery();
+    tq.schema = "schema";
+    tq.tableName = "table";
+  }
+
+  @Test
+  public void generateQuerySimple() {
+    assertThat(generateQuery(tq), is("SELECT * FROM schema.table LIMIT 500"));
+  }
+
+  @Test
+  public void generateQueryFilter() {
+    tq.columnFilters = List.of(new ColumnFilter("col", ">", "val"));
+    assertThat(generateQuery(tq), is("SELECT * FROM schema.table WHERE (\"col\" > 'val') LIMIT 500"));
+  }
+
+  @Test
+  public void generateQueryFilterWithSingleQuotes() {
+    tq.columnFilters = List.of(new ColumnFilter("col", ">", "it's cool, it's \"masked\""));
+    assertThat(generateQuery(tq), is(
+        "SELECT * FROM schema.table WHERE (\"col\" > 'it''s cool, it''s \"masked\"') LIMIT 500"));
+  }
+
+  @Test
+  public void generateQueryFilterWithDoubleQuotes() {
+    tq.columnFilters = List.of(new ColumnFilter("\"foo\"", ">", "val"));
+    var e = assertThrows(ResponseStatusException.class, () -> generateQuery(tq));
+    assertThat(e.getMessage(), containsString("must not contain quotes"));
+  }
+
+  @Test
+  public void generateQueryShowColumns() {
+    tq.showColumns = List.of("col1", "col2");
+    assertThat(generateQuery(tq), is("SELECT \"col1\",\"col2\" FROM schema.table LIMIT 500"));
+  }
+
+  @Test
+  public void generateQueryShowColumnsWithQuotes() {
+    tq.showColumns = List.of("col1", "col2", "foo\"bar");
+    var e = assertThrows(ResponseStatusException.class, () -> generateQuery(tq));
+    assertThat(e.getMessage(), containsString("must not contain quotes"));
+  }
+
+  private static String generateQuery(TableQuery tableQuery) {
+    return new QueryServiceImpl().generateQuery(tableQuery);
+  }
+
+}


### PR DESCRIPTION
ColumnFilter.value doesn't escape single quotes.

ColumnFilter.key and OrderingCriterion.key pass double quotes to the database without escapting.

This results in SQL injection.