### PR TITLE
MODLDP-44: Upgrade snakeyaml and postgresql fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,11 @@
 
   <properties>
     <java.version>11</java.version>
+    <!-- After upgrading to spring-boot-starter-parent >= 3.0.0 remove
+         the snakeyaml and postgresql security upgrades:
+    -->
+    <snakeyaml.version>1.33</snakeyaml.version>
+    <postgresql.version>42.5.1</postgresql.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Upgrade snakeyaml from 1.30 to 1.33 fixing Denial of Service (DoS) and Stack-based Buffer Overflow:

https://www.cve.org/CVERecord?id=CVE-2022-25857
https://www.cve.org/CVERecord?id=CVE-2022-38749
https://www.cve.org/CVERecord?id=CVE-2022-38751
https://www.cve.org/CVERecord?id=CVE-2022-38752
https://www.cve.org/CVERecord?id=CVE-2022-38750
https://www.cve.org/CVERecord?id=CVE-2022-41854

Upgrade postgresql from 42.3.7 to 42.5.1 fixing Information Exposure:

https://www.cve.org/CVERecord?id=CVE-2022-41946