### PR TITLE
MODLDP-47: Upgrade Spring Boot from 2.7.5 to 2.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.5</version>
+    <version>2.7.9</version>
     <relativePath />
   </parent>
   <groupId>org.folio</groupId>


### PR DESCRIPTION
Upgrading Spring Boot from 2.7.5 to 2.7.9 fixes Denial of Service (DoS) and Improper Input Validation in tomcat-embed-core:

https://nvd.nist.gov/vuln/detail/CVE-2023-24998
https://nvd.nist.gov/vuln/detail/CVE-2022-45143